### PR TITLE
Feature/account password reset

### DIFF
--- a/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/DefaultRequestResetPasswordUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/DefaultRequestResetPasswordUseCase.java
@@ -1,0 +1,42 @@
+package com.kaua.ecommerce.users.application.account.update.password;
+
+import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailCommand;
+import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailUseCase;
+import com.kaua.ecommerce.users.application.gateways.AccountGateway;
+import com.kaua.ecommerce.users.domain.accounts.Account;
+import com.kaua.ecommerce.users.domain.accounts.mail.AccountMailType;
+import com.kaua.ecommerce.users.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.users.domain.utils.IdUtils;
+import com.kaua.ecommerce.users.domain.utils.InstantUtils;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+public class DefaultRequestResetPasswordUseCase extends RequestResetPasswordUseCase {
+
+    private final AccountGateway accountGateway;
+    private final CreateAccountMailUseCase createAccountMailUseCase;
+
+    public DefaultRequestResetPasswordUseCase(
+            final AccountGateway accountGateway,
+            final CreateAccountMailUseCase createAccountMailUseCase
+    ) {
+        this.accountGateway = Objects.requireNonNull(accountGateway);
+        this.createAccountMailUseCase = Objects.requireNonNull(createAccountMailUseCase);
+    }
+
+    @Override
+    public void execute(RequestResetPasswordCommand input) {
+        final var aAccount = accountGateway.findByEmail(input.email())
+                .orElseThrow(() -> NotFoundException.with(Account.class, input.email()));
+
+        final var aCommand = CreateAccountMailCommand.with(
+                aAccount.getId().getValue(),
+                IdUtils.generate().replace("-", ""),
+                AccountMailType.PASSWORD_RESET,
+                InstantUtils.now().plus(30, ChronoUnit.MINUTES)
+        );
+
+        this.createAccountMailUseCase.execute(aCommand);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordCommand.java
@@ -1,0 +1,8 @@
+package com.kaua.ecommerce.users.application.account.update.password;
+
+public record RequestResetPasswordCommand(String email) {
+
+    public static RequestResetPasswordCommand with(String email) {
+        return new RequestResetPasswordCommand(email);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordUseCase.java
@@ -1,0 +1,6 @@
+package com.kaua.ecommerce.users.application.account.update.password;
+
+import com.kaua.ecommerce.users.application.UnitUseCase;
+
+public abstract class RequestResetPasswordUseCase extends UnitUseCase<RequestResetPasswordCommand> {
+}

--- a/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/reset/DefaultResetPasswordUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/reset/DefaultResetPasswordUseCase.java
@@ -1,0 +1,53 @@
+package com.kaua.ecommerce.users.application.account.update.password.reset;
+
+import com.kaua.ecommerce.users.application.either.Either;
+import com.kaua.ecommerce.users.application.gateways.AccountGateway;
+import com.kaua.ecommerce.users.application.gateways.AccountMailGateway;
+import com.kaua.ecommerce.users.application.gateways.EncrypterGateway;
+import com.kaua.ecommerce.users.domain.accounts.mail.AccountMail;
+import com.kaua.ecommerce.users.domain.exceptions.NotFoundException;
+import com.kaua.ecommerce.users.domain.validation.Error;
+import com.kaua.ecommerce.users.domain.validation.handler.NotificationHandler;
+
+import java.util.Objects;
+
+public class DefaultResetPasswordUseCase extends ResetPasswordUseCase {
+
+    private final AccountGateway accountGateway;
+    private final EncrypterGateway encrypterGateway;
+    private final AccountMailGateway accountMailGateway;
+
+    public DefaultResetPasswordUseCase(
+            final AccountGateway accountGateway,
+            final EncrypterGateway encrypterGateway,
+            final AccountMailGateway accountMailGateway
+    ) {
+        this.accountGateway = Objects.requireNonNull(accountGateway);
+        this.encrypterGateway = Objects.requireNonNull(encrypterGateway);
+        this.accountMailGateway = Objects.requireNonNull(accountMailGateway);
+    }
+
+    @Override
+    public Either<NotificationHandler, Boolean> execute(ResetPasswordCommand input) {
+        final var notification = NotificationHandler.create();
+
+        final var aAccountMail = this.accountMailGateway.findByToken(input.token())
+                .orElseThrow(() -> NotFoundException.with(AccountMail.class, input.token()));
+
+        if (aAccountMail.isExpired()) {
+            return Either.left(notification.append(new Error("Token expired")));
+        }
+
+        final var aAccount = aAccountMail.getAccount().update(
+                this.encrypterGateway.encrypt(input.newPassword()),
+                aAccountMail.getAccount().getAvatarUrl()
+        );
+
+        this.accountGateway.update(aAccount);
+        this.accountMailGateway.deleteById(aAccountMail.getId().getValue());
+
+        return notification.hasError()
+                ? Either.left(notification)
+                : Either.right(true);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordCommand.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordCommand.java
@@ -1,0 +1,8 @@
+package com.kaua.ecommerce.users.application.account.update.password.reset;
+
+public record ResetPasswordCommand(String token, String newPassword) {
+
+    public static ResetPasswordCommand with(String token, String newPassword) {
+        return new ResetPasswordCommand(token, newPassword);
+    }
+}

--- a/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordUseCase.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordUseCase.java
@@ -1,0 +1,8 @@
+package com.kaua.ecommerce.users.application.account.update.password.reset;
+
+import com.kaua.ecommerce.users.application.UseCase;
+import com.kaua.ecommerce.users.application.either.Either;
+import com.kaua.ecommerce.users.domain.validation.handler.NotificationHandler;
+
+public abstract class ResetPasswordUseCase extends UseCase<ResetPasswordCommand, Either<NotificationHandler, Boolean>> {
+}

--- a/application/src/main/java/com/kaua/ecommerce/users/application/gateways/AccountGateway.java
+++ b/application/src/main/java/com/kaua/ecommerce/users/application/gateways/AccountGateway.java
@@ -12,5 +12,7 @@ public interface AccountGateway {
 
     Optional<Account> findById(String aId);
 
+    Optional<Account> findByEmail(String aEmail);
+
     Account update(Account aAccount);
 }

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/create/CreateAccountUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/create/CreateAccountUseCaseTest.java
@@ -34,7 +34,7 @@ public class CreateAccountUseCaseTest {
     private EncrypterGateway encrypterGateway;
 
     @Test
-    public void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() {
+    void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -76,7 +76,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidFirstName_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidFirstName_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "";
         final var aLastName = "Silveira";
@@ -103,7 +103,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidFirstNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidFirstNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "F ";
         final var aLastName = "Silveira";
@@ -130,7 +130,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidFirstNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidFirstNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = """
                 O empenho em analisar a execução dos pontos do programa causa impacto indireto na
@@ -167,7 +167,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidLastName_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidLastName_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final String aLastName = null;
@@ -194,7 +194,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidLastNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidLastNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "S ";
@@ -221,7 +221,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidLastNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidLastNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = """
@@ -258,7 +258,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidEmail_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidEmail_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -285,7 +285,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnExistingEmail_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnExistingEmail_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -315,7 +315,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPassword_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPassword_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -342,7 +342,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -369,7 +369,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -406,7 +406,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordWithoutUpperLetterAndLowerLetter_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPasswordWithoutUpperLetterAndLowerLetter_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -433,7 +433,7 @@ public class CreateAccountUseCaseTest {
     }
 
     @Test
-    public void givenAValidAccountId_whenCallFrom_shouldReturnId() {
+    void givenAValidAccountId_whenCallFrom_shouldReturnId() {
         final var aAccountId = AccountID.unique();
 
         final var aOutput = CreateAccountOutput.from(aAccountId.getValue(), null, null);

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/mail/confirm/ConfirmAccountMailUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/mail/confirm/ConfirmAccountMailUseCaseTest.java
@@ -36,7 +36,7 @@ public class ConfirmAccountMailUseCaseTest {
     private DefaultConfirmAccountMailUseCase useCase;
 
     @Test
-    public void givenAValidCommand_whenCallConfirmAccount_thenShouldReturneTrue() {
+    void givenAValidCommand_whenCallConfirmAccount_thenShouldReturneTrue() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(
@@ -86,7 +86,7 @@ public class ConfirmAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidCommand_whenCallConfirmAccount_thenShouldThrowsDomainException() {
+    void givenAnInvalidCommand_whenCallConfirmAccount_thenShouldThrowsDomainException() {
         // given
         final var expectedErrorMessage = "Token expired";
         final var expectedErrorCount = 1;
@@ -128,7 +128,7 @@ public class ConfirmAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAValidCommandWithAccountMailNotPersisted_whenCallConfirmAccount_thenShouldReturnNotFoundException() {
+    void givenAValidCommandWithAccountMailNotPersisted_whenCallConfirmAccount_thenShouldReturnNotFoundException() {
         // given
         final var expectedErrorMessage = "AccountMail with id empty was not found";
 
@@ -139,7 +139,7 @@ public class ConfirmAccountMailUseCaseTest {
                 .thenReturn(Optional.empty());
 
         final var aOutput = Assertions.assertThrows(NotFoundException.class,
-                () -> useCase.execute(aCommand).getLeft());
+                () -> useCase.execute(aCommand));
 
         // then
         Assertions.assertEquals(expectedErrorMessage, aOutput.getMessage());

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/mail/create/CreateAccountMailUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/mail/create/CreateAccountMailUseCaseTest.java
@@ -41,7 +41,7 @@ public class CreateAccountMailUseCaseTest {
     private DefaultCreateAccountMailUseCase useCase;
 
     @Test
-    public void givenAValidCommand_whenCallCreateAccountMail_thenShouldReturneAnAccountMail() {
+    void givenAValidCommand_whenCallCreateAccountMail_thenShouldReturneAnAccountMail() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(
@@ -90,7 +90,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidToken_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidToken_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = "";
         final var aAccount = Account.newAccount(
@@ -130,7 +130,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidTokenLenghtMoreThan36_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidTokenLenghtMoreThan36_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = RandomStringUtils.generateValue(37);
         final var aAccount = Account.newAccount(
@@ -170,7 +170,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidAccountIdIsNull_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidAccountIdIsNull_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final String aAccount = null;
@@ -202,7 +202,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidAccount_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidAccount_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = "84045cfc-705f-4418-bf4b-155d5d11f69f";
@@ -236,7 +236,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidAccountMailType_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidAccountMailType_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(
@@ -276,7 +276,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidExpiresAt_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidExpiresAt_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(
@@ -316,7 +316,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidExpiresAtBeforeNow_whenCallCreateAccountMail_thenShouldReturnAnError() {
+    void givenAnInvalidExpiresAtBeforeNow_whenCallCreateAccountMail_thenShouldReturnAnError() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(
@@ -356,7 +356,7 @@ public class CreateAccountMailUseCaseTest {
     }
 
     @Test
-    public void givenAValidCommandButExistingMailWithType_whenCallCreateAccountMail_thenShouldDeleteExistMailAndReturneAnAccountMail() {
+    void givenAValidCommandButExistingMailWithType_whenCallCreateAccountMail_thenShouldDeleteExistMailAndReturneAnAccountMail() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordUseCaseTest.java
@@ -29,7 +29,7 @@ public class RequestResetPasswordUseCaseTest {
     private DefaultRequestResetPasswordUseCase useCase;
 
     @Test
-    public void givenAValidCommand_whenCallRequestResetPassowrd_thenShouldDoesNotThrow() {
+    void givenAValidCommand_whenCallRequestResetPassowrd_thenShouldDoesNotThrow() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -60,7 +60,7 @@ public class RequestResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidCommand_whenCallRequestResetPassowrd_thenShouldThrowException() {
+    void givenAnInvalidCommand_whenCallRequestResetPassowrd_thenShouldThrowException() {
         // given
         final var aEmail = "teste@teste.com";
         final var expectedErrorMessage = "Account with id teste@teste.com was not found";

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/RequestResetPasswordUseCaseTest.java
@@ -1,0 +1,84 @@
+package com.kaua.ecommerce.users.application.account.update.password;
+
+import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailUseCase;
+import com.kaua.ecommerce.users.application.gateways.AccountGateway;
+import com.kaua.ecommerce.users.domain.accounts.Account;
+import com.kaua.ecommerce.users.domain.accounts.mail.AccountMailType;
+import com.kaua.ecommerce.users.domain.exceptions.NotFoundException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Objects;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class RequestResetPasswordUseCaseTest {
+
+    @Mock
+    private AccountGateway accountGateway;
+
+    @Mock
+    private CreateAccountMailUseCase createAccountMailUseCase;
+
+    @InjectMocks
+    private DefaultRequestResetPasswordUseCase useCase;
+
+    @Test
+    public void givenAValidCommand_whenCallRequestResetPassowrd_thenShouldDoesNotThrow() {
+        // given
+        final var aFirstName = "Fulano";
+        final var aLastName = "Silveira";
+        final var aEmail = "teste@teste.com";
+        final var aPassword = "1234567Ab";
+        final var aAccount = Account.newAccount(
+                aFirstName,
+                aLastName,
+                aEmail,
+                aPassword
+        );
+
+        final var aCommand = RequestResetPasswordCommand.with(aEmail);
+
+        // when
+        Mockito.when(accountGateway.findByEmail(Mockito.any()))
+                .thenReturn(Optional.of(aAccount));
+
+        Assertions.assertDoesNotThrow(() -> useCase.execute(aCommand));
+
+        Mockito.verify(accountGateway, Mockito.times(1))
+                .findByEmail(aEmail);
+        Mockito.verify(createAccountMailUseCase, Mockito.times(1))
+                .execute(Mockito.argThat(cmd ->
+                        Objects.equals(aAccount.getId().getValue(), cmd.accountId()) &&
+                        Objects.equals(AccountMailType.PASSWORD_RESET, cmd.type())
+                ));
+    }
+
+    @Test
+    public void givenAnInvalidCommand_whenCallRequestResetPassowrd_thenShouldThrowException() {
+        // given
+        final var aEmail = "teste@teste.com";
+        final var expectedErrorMessage = "Account with id teste@teste.com was not found";
+
+        final var aCommand = RequestResetPasswordCommand.with(aEmail);
+
+        // when
+        Mockito.when(accountGateway.findByEmail(Mockito.any()))
+                .thenReturn(Optional.empty());
+
+        final var aException = Assertions.assertThrows(NotFoundException.class,
+                () -> useCase.execute(aCommand));
+
+        Assertions.assertEquals(expectedErrorMessage, aException.getMessage());
+
+        Mockito.verify(accountGateway, Mockito.times(1))
+                .findByEmail(aEmail);
+        Mockito.verify(createAccountMailUseCase, Mockito.times(0))
+                .execute(Mockito.any());
+    }
+}

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordUseCaseTest.java
@@ -131,6 +131,8 @@ public class ResetPasswordUseCaseTest {
 
         Mockito.verify(accountMailGateway, Mockito.times(1))
                 .findByToken(Mockito.any());
+        Mockito.verify(encrypterGateway, Mockito.times(0))
+                .encrypt(Mockito.any());
         Mockito.verify(accountGateway, Mockito.times(0))
                 .update(Mockito.any());
         Mockito.verify(accountMailGateway, Mockito.times(0))
@@ -156,6 +158,189 @@ public class ResetPasswordUseCaseTest {
 
         Mockito.verify(accountMailGateway, Mockito.times(1))
                 .findByToken(Mockito.any());
+        Mockito.verify(encrypterGateway, Mockito.times(0))
+                .encrypt(Mockito.any());
+        Mockito.verify(accountGateway, Mockito.times(0))
+                .update(Mockito.any());
+        Mockito.verify(accountMailGateway, Mockito.times(0))
+                .deleteById(Mockito.any());
+    }
+
+    @Test
+    public void givenAnInvalidPassword_whenCallResetPAssword_thenShouldReturnAnError() {
+        // given
+        final var aAccount = Account.newAccount(
+                "Fulano",
+                "Silveira",
+                "teste@teste.com",
+                "1234567Ab"
+        );
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aAccountMail = AccountMail.newAccountMail(
+                aToken,
+                AccountMailType.PASSWORD_RESET,
+                aAccount,
+                InstantUtils.now().plus(30, ChronoUnit.MINUTES)
+        );
+        final var aPassword = "";
+
+        final var expectedErrorMessage = "'password' should not be null or blank";
+        final var expectedErrorCount = 1;
+
+        final var aCommand = ResetPasswordCommand.with(aToken, aPassword);
+
+        // when
+        Mockito.when(accountMailGateway.findByToken(Mockito.any()))
+                .thenReturn(Optional.of(aAccountMail));
+
+        final var aNotification = useCase.execute(aCommand).getLeft();
+
+        // then
+        Assertions.assertEquals(expectedErrorCount, aNotification.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aNotification.getErrors().get(0).message());
+
+        Mockito.verify(accountMailGateway, Mockito.times(1))
+                .findByToken(Mockito.any());
+        Mockito.verify(encrypterGateway, Mockito.times(0))
+                .encrypt(Mockito.any());
+        Mockito.verify(accountGateway, Mockito.times(0))
+                .update(Mockito.any());
+        Mockito.verify(accountMailGateway, Mockito.times(0))
+                .deleteById(Mockito.any());
+    }
+
+    @Test
+    public void givenAnInvalidPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnAnError() {
+        // given
+        final var aAccount = Account.newAccount(
+                "Fulano",
+                "Silveira",
+                "teste@teste.com",
+                "1234567Ab"
+        );
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aAccountMail = AccountMail.newAccountMail(
+                aToken,
+                AccountMailType.PASSWORD_RESET,
+                aAccount,
+                InstantUtils.now().plus(30, ChronoUnit.MINUTES)
+        );
+        final var aPassword = "123";
+        final var expectedErrorMessage = "'password' must be between 8 and 255 characters";
+        final var expectedErrorCount = 1;
+
+        final var aCommand = ResetPasswordCommand.with(aToken, aPassword);
+
+        // when
+        Mockito.when(accountMailGateway.findByToken(Mockito.any()))
+                .thenReturn(Optional.of(aAccountMail));
+
+        final var aNotification = useCase.execute(aCommand).getLeft();
+
+        // then
+        Assertions.assertEquals(expectedErrorCount, aNotification.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aNotification.getErrors().get(0).message());
+
+        Mockito.verify(accountMailGateway, Mockito.times(1))
+                .findByToken(Mockito.any());
+        Mockito.verify(encrypterGateway, Mockito.times(0))
+                .encrypt(Mockito.any());
+        Mockito.verify(accountGateway, Mockito.times(0))
+                .update(Mockito.any());
+        Mockito.verify(accountMailGateway, Mockito.times(0))
+                .deleteById(Mockito.any());
+    }
+
+    @Test
+    public void givenAnInvalidPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
+        // given
+        final var aAccount = Account.newAccount(
+                "Fulano",
+                "Silveira",
+                "teste@teste.com",
+                "1234567Ab"
+        );
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aAccountMail = AccountMail.newAccountMail(
+                aToken,
+                AccountMailType.PASSWORD_RESET,
+                aAccount,
+                InstantUtils.now().plus(30, ChronoUnit.MINUTES)
+        );
+        final var aPassword = """
+                O empenho em analisar a execução dos pontos do programa causa impacto indireto na
+                reavaliação dos modos de operação convencionais. Podemos já vislumbrar o modo pelo 
+                qual a constante divulgação das informações talvez venha a ressaltar a relatividade 
+                de alternativas às soluções ortodoxas. Assim mesmo, a contínua expansão de nossa 
+                atividade assume importantes posições no estabelecimento das condições inegavelmente 
+                apropriadas. No entanto, não podemos esquecer que a revolução dos costumes auxilia 
+                a preparação e a composição das novas proposições. As experiências acumuladas 
+                demonstram que o novo modelo estrutural aqui preconizado acarreta um processo 
+                de reformulação e modernização do processo de comunicação como um todo.
+                """;
+
+        final var expectedErrorMessage = "'password' must be between 8 and 255 characters";
+        final var expectedErrorCount = 1;
+
+        final var aCommand = ResetPasswordCommand.with(aToken, aPassword);
+
+        // when
+        Mockito.when(accountMailGateway.findByToken(Mockito.any()))
+                .thenReturn(Optional.of(aAccountMail));
+
+        final var aNotification = useCase.execute(aCommand).getLeft();
+
+        // then
+        Assertions.assertEquals(expectedErrorCount, aNotification.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aNotification.getErrors().get(0).message());
+
+        Mockito.verify(accountMailGateway, Mockito.times(1))
+                .findByToken(Mockito.any());
+        Mockito.verify(encrypterGateway, Mockito.times(0))
+                .encrypt(Mockito.any());
+        Mockito.verify(accountGateway, Mockito.times(0))
+                .update(Mockito.any());
+        Mockito.verify(accountMailGateway, Mockito.times(0))
+                .deleteById(Mockito.any());
+    }
+
+    @Test
+    public void givenAnInvalidPasswordWithoutUpperLetterAndLowerLetter_whenCallCreateAccount_thenShouldReturnAnError() {
+        // given
+        final var aAccount = Account.newAccount(
+                "Fulano",
+                "Silveira",
+                "teste@teste.com",
+                "1234567Ab"
+        );
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aAccountMail = AccountMail.newAccountMail(
+                aToken,
+                AccountMailType.PASSWORD_RESET,
+                aAccount,
+                InstantUtils.now().plus(30, ChronoUnit.MINUTES)
+        );
+
+        final var aPassword = "12345678";
+        final var expectedErrorMessage = "'password' should contain at least one uppercase letter, one lowercase letter and one number";
+        final var expectedErrorCount = 1;
+
+        final var aCommand = ResetPasswordCommand.with(aToken, aPassword);
+
+        // when
+        Mockito.when(accountMailGateway.findByToken(Mockito.any()))
+                .thenReturn(Optional.of(aAccountMail));
+
+        final var aNotification = useCase.execute(aCommand).getLeft();
+
+        // then
+        Assertions.assertEquals(expectedErrorCount, aNotification.getErrors().size());
+        Assertions.assertEquals(expectedErrorMessage, aNotification.getErrors().get(0).message());
+
+        Mockito.verify(accountMailGateway, Mockito.times(1))
+                .findByToken(Mockito.any());
+        Mockito.verify(encrypterGateway, Mockito.times(0))
+                .encrypt(Mockito.any());
         Mockito.verify(accountGateway, Mockito.times(0))
                 .update(Mockito.any());
         Mockito.verify(accountMailGateway, Mockito.times(0))

--- a/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordUseCaseTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/account/update/password/reset/ResetPasswordUseCaseTest.java
@@ -40,7 +40,7 @@ public class ResetPasswordUseCaseTest {
     private DefaultResetPasswordUseCase useCase;
 
     @Test
-    public void givenAValidCommand_whenCallResetPassword_thenShouldReturneTrue() {
+    void givenAValidCommand_whenCallResetPassword_thenShouldReturneTrue() {
         // given
         final var aToken = RandomStringUtils.generateValue(36);
         final var aAccount = Account.newAccount(
@@ -95,7 +95,7 @@ public class ResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidCommand_whenCallResetPassword_thenShouldThrowsDomainException() {
+    void givenAnInvalidCommand_whenCallResetPassword_thenShouldThrowsDomainException() {
         // given
         final var expectedErrorMessage = "Token expired";
         final var expectedErrorCount = 1;
@@ -140,7 +140,7 @@ public class ResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidToken_whenCallResetPassword_thenShouldReturnNotFoundException() {
+    void givenAnInvalidToken_whenCallResetPassword_thenShouldReturnNotFoundException() {
         // given
         final var expectedErrorMessage = "AccountMail with id empty was not found";
 
@@ -151,7 +151,7 @@ public class ResetPasswordUseCaseTest {
                 .thenReturn(Optional.empty());
 
         final var aOutput = Assertions.assertThrows(NotFoundException.class,
-                () -> useCase.execute(aCommand).getLeft());
+                () -> useCase.execute(aCommand));
 
         // then
         Assertions.assertEquals(expectedErrorMessage, aOutput.getMessage());
@@ -167,7 +167,7 @@ public class ResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPassword_whenCallResetPAssword_thenShouldReturnAnError() {
+    void givenAnInvalidPassword_whenCallResetPAssword_thenShouldReturnAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -210,7 +210,7 @@ public class ResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -252,7 +252,7 @@ public class ResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -305,7 +305,7 @@ public class ResetPasswordUseCaseTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordWithoutUpperLetterAndLowerLetter_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPasswordWithoutUpperLetterAndLowerLetter_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",

--- a/application/src/test/java/com/kaua/ecommerce/users/application/either/EitherTest.java
+++ b/application/src/test/java/com/kaua/ecommerce/users/application/either/EitherTest.java
@@ -8,7 +8,7 @@ import java.util.NoSuchElementException;
 public class EitherTest {
 
     @Test
-    public void testLeft() {
+    void testLeft() {
         Either<Integer, String> either = Either.left(42);
         Assertions.assertTrue(either.isLeft());
         Assertions.assertFalse(either.isRight());
@@ -26,7 +26,7 @@ public class EitherTest {
     }
 
     @Test
-    public void testRightWithLeftMethods() {
+    void testRightWithLeftMethods() {
         Either<Integer, String> either = Either.right("Hello");
         Assertions.assertFalse(either.isLeft());
         Assertions.assertTrue(either.isRight());
@@ -38,7 +38,7 @@ public class EitherTest {
     }
 
     @Test
-    public void testLeftWithRightMethods() {
+    void testLeftWithRightMethods() {
         Either<Integer, String> either = Either.left(42);
         Assertions.assertTrue(either.isLeft());
         Assertions.assertFalse(either.isRight());
@@ -50,7 +50,7 @@ public class EitherTest {
     }
 
     @Test
-    public void testBaseMethods() {
+    void testBaseMethods() {
         Either<Integer, String> either = new Either.BaseMethods<>();
         Assertions.assertThrows(UnsupportedOperationException.class, either::isLeft);
         Assertions.assertThrows(UnsupportedOperationException.class, either::isRight);

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/EntityTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/EntityTest.java
@@ -62,7 +62,7 @@ public class EntityTest {
 
         Assertions.assertNotNull(entity);
         Assertions.assertEquals(sampleId, entity.getId());
-        Assertions.assertNotEquals(entity, null);
+        Assertions.assertNotEquals(null, entity);
         Assertions.assertNotEquals(entity, new Object());
     }
 

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/accounts/AccountTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/accounts/AccountTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 public class AccountTest {
 
     @Test
-    public void givenAValidValues_whenCallsNewAccount_thenAnAccountShouldBeCreated() {
+    void givenAValidValues_whenCallsNewAccount_thenAnAccountShouldBeCreated() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -48,14 +48,16 @@ public class AccountTest {
         Assertions.assertEquals(aEvent, aAccount.getDomainEvents().get(0));
         Assertions.assertEquals(expectedEventCount, aAccount.getDomainEvents().size());
 
-        Assertions.assertTrue(aAccount.getId().equals(aAccount.getId()));
-        Assertions.assertFalse(aAccount.getId().equals(AccountID.unique()));
+        Assertions.assertEquals(aAccount.getId(), aAccount.getId());
+        Assertions.assertNotEquals(AccountID.unique(), aAccount.getId());
+        Assertions.assertNotNull(aAccount.getId());
         Assertions.assertFalse(aAccount.getId().equals(null));
-        Assertions.assertNotNull(aAccount.getId().hashCode());
+        Assertions.assertFalse(aAccount.getId().equals(new Object()));
+        Assertions.assertNotEquals(1201212, aAccount.getId().hashCode());
     }
 
     @Test
-    public void givenAnInvalidFirstName_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidFirstName_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "";
         final var aLastName = "Pereira";
@@ -81,7 +83,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidFirstNameLengthLessThan3_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidFirstNameLengthLessThan3_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Ka ";
         final var aLastName = "Pereira";
@@ -107,7 +109,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidFirstNameLengthMoreThan255_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidFirstNameLengthMoreThan255_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = RandomStringUtils.generateValue(256);
         final var aLastName = "Pereira";
@@ -133,7 +135,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidLastName_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidLastName_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final String aLastName = null;
@@ -159,7 +161,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidLastNameLengthLessThan3_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidLastNameLengthLessThan3_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pe ";
@@ -185,7 +187,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidLastNameLengthMoreThan255_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidLastNameLengthMoreThan255_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = RandomStringUtils.generateValue(256);
@@ -211,7 +213,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidEmail_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidEmail_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -237,7 +239,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPassword_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPassword_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -263,7 +265,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthLessThan8_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPasswordLengthLessThan8_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -289,7 +291,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthMoreThan255_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPasswordLengthMoreThan255_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -315,7 +317,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordButNotContainsLowerAndUpercaseLetter_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPasswordButNotContainsLowerAndUpercaseLetter_whenCallsNewAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -341,7 +343,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAValidValues_whenCallsUpdateAccount_thenAnAccountShouldBeUpdated() {
+    void givenAValidValues_whenCallsUpdateAccount_thenAnAccountShouldBeUpdated() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -378,7 +380,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPassword_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPassword_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -410,7 +412,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthLessThan8_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPasswordLengthLessThan8_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -442,7 +444,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordLengthMoreThan255_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPasswordLengthMoreThan255_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -474,7 +476,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAnInvalidPasswordButNotContainsLowerAndUpercaseLetter_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidPasswordButNotContainsLowerAndUpercaseLetter_whenCallsUpdateAccount_thenAnExceptionShouldBeThrown() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";
@@ -506,7 +508,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenValidValues_whenCalledWithInAccount_shouldReturnAnAccountObjectWithDataEqualToWhatWasPassed() {
+    void givenValidValues_whenCalledWithInAccount_shouldReturnAnAccountObjectWithDataEqualToWhatWasPassed() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Teste";
@@ -560,7 +562,7 @@ public class AccountTest {
     }
 
     @Test
-    public void givenAValidAccountWatingConfirmation_whenCallsConfirm_thenAnAccountShouldBeConfirmed() {
+    void givenAValidAccountWatingConfirmation_whenCallsConfirm_thenAnAccountShouldBeConfirmed() {
         // given
         final var aFirstName = "Kaua";
         final var aLastName = "Pereira";

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/accounts/mail/AccountMailTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/accounts/mail/AccountMailTest.java
@@ -14,7 +14,7 @@ import java.time.temporal.ChronoUnit;
 public class AccountMailTest {
 
     @Test
-    public void givenAValidValues_whenCallNewAccountMail_thenAnAccountShouldBeCreated() {
+    void givenAValidValues_whenCallNewAccountMail_thenAnAccountShouldBeCreated() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -37,7 +37,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidTokenNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidTokenNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final String aToken = null;
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -59,7 +59,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidTokenBlank_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidTokenBlank_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = "";
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -81,7 +81,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidTokenLenghtMoreThan36_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidTokenLenghtMoreThan36_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = RandomStringUtils.generateValue(37);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -103,7 +103,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidTypeNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidTypeNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = RandomStringUtils.generateValue(36);
         final AccountMailType aType = null;
         final var aAccount = Account.newAccount(
@@ -125,7 +125,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidAccountNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidAccountNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final Account aAccount = null;
@@ -143,7 +143,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAValidAccountButAfterSetNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAValidAccountButAfterSetNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -167,7 +167,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidExpirestAtNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidExpirestAtNull_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -189,7 +189,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAnInvalidExpirestAtBeforeNow_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
+    void givenAnInvalidExpirestAtBeforeNow_whenCallNewAccountMail_thenAnExceptionShouldBeThrown() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -211,7 +211,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAValidValues_whenCallHashCodeAndEqualsAndFrom_thenShouldBeTrue() {
+    void givenAValidValues_whenCallHashCodeAndEqualsAndFrom_thenShouldBeTrue() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -224,15 +224,15 @@ public class AccountMailTest {
 
         final var aAccountMail = AccountMail.newAccountMail(aToken, aType, aAccount, aExpiresAt);
 
-        Assertions.assertTrue(aAccountMail.getId().equals(aAccountMail.getId()));
-        Assertions.assertNotNull(aAccountMail.getId().hashCode());
+        Assertions.assertEquals(aAccountMail.getId(), aAccountMail.getId());
+        Assertions.assertNotEquals(1287983127, aAccountMail.getId().hashCode());
 
         Assertions.assertNotNull(aAccountMailIdFrom);
         Assertions.assertInstanceOf(AccountMailID.class, aAccountMailIdFrom);
     }
 
     @Test
-    public void givenAInvalidValues_whenCallHashCodeAndEqualsAndFrom_thenShouldBeFalse() {
+    void givenAInvalidValues_whenCallHashCodeAndEqualsAndFrom_thenShouldBeFalse() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -244,13 +244,13 @@ public class AccountMailTest {
 
         final var aAccountMail = AccountMail.newAccountMail(aToken, aType, aAccount, aExpiresAt);
 
-        Assertions.assertFalse(aAccountMail.getId().equals(AccountMailID.unique()));
+        Assertions.assertNotEquals(AccountMailID.unique(), aAccountMail.getId());
         Assertions.assertFalse(aAccountMail.getId().equals(null));
         Assertions.assertFalse(aAccountMail.getId().equals(new Object()));
     }
 
     @Test
-    public void givenValidValues_whenCalledWithInAccountMail_shouldReturnAnAccountMailObjectWithDataEqualToWhatWasPassed() {
+    void givenValidValues_whenCalledWithInAccountMail_shouldReturnAnAccountMailObjectWithDataEqualToWhatWasPassed() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -283,7 +283,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAValidValues_whenCallIsExpired_shouldReturnFalse() {
+    void givenAValidValues_whenCallIsExpired_shouldReturnFalse() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -300,7 +300,7 @@ public class AccountMailTest {
     }
 
     @Test
-    public void givenAInvalidValues_whenCallIsExpired_shouldReturnTrue() {
+    void givenAInvalidValues_whenCallIsExpired_shouldReturnTrue() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/DomainExceptionTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/DomainExceptionTest.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class DomainExceptionTest {
 
     @Test
-    public void givenAValidListOfError_whenCallDomainExceptionWith_ThenReturnDomainException() {
+    void givenAValidListOfError_whenCallDomainExceptionWith_ThenReturnDomainException() {
         // given
         var errors = List.of(new Error("Common Error"));
         // when

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/NotFoundExceptionTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/NotFoundExceptionTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 public class NotFoundExceptionTest {
 
     @Test
-    public void givenAValidAggregate_whenCallNotFoundExceptionWith_ThenReturnNotFoundException() {
+    void givenAValidAggregate_whenCallNotFoundExceptionWith_ThenReturnNotFoundException() {
         // given
         final var aggregate = Account.class;
         final var aId = "123";

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/NotificationTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/NotificationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 public class NotificationTest {
 
     @Test
-    public void givenAValidError_whenCallCreateNotification_thenShouldReturnTrueHasError() {
+    void givenAValidError_whenCallCreateNotification_thenShouldReturnTrueHasError() {
         // given
         final var error = new Error("Common Error");
 
@@ -25,7 +25,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void givenAValidErrors_whenCallAppendNotification_thenShouldReturnANotificationWithError() {
+    void givenAValidErrors_whenCallAppendNotification_thenShouldReturnANotificationWithError() {
         // given
         final var error = new Error("Common Error");
 
@@ -39,7 +39,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void givenAValidEmptyError_whenCallAppendNotification_thenShouldReturnANotificationWithoutError() {
+    void givenAValidEmptyError_whenCallAppendNotification_thenShouldReturnANotificationWithoutError() {
         final var notification = NotificationHandler.create();
 
         // then
@@ -48,7 +48,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void givenAValidValidation_whenCallValidate_thenShouldReturnNotificationEmpty() {
+    void givenAValidValidation_whenCallValidate_thenShouldReturnNotificationEmpty() {
         final String aName = null;
 
         final var aNotification = NotificationHandler.create();
@@ -59,7 +59,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void givenAValidValidation_whenCallValidate_thenShouldDoesNotThrow() {
+    void givenAValidValidation_whenCallValidate_thenShouldDoesNotThrow() {
         Validation validation = () -> {};
         NotificationHandler handler = NotificationHandler.create();
 
@@ -67,7 +67,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void givenAValidValidation_whenCallValidate_thenShouldThrowsException() {
+    void givenAValidValidation_whenCallValidate_thenShouldThrowsException() {
         final var expectedErrorMessage = "Cannot invoke \"com.kaua.ecommerce.users.domain.validation.Validation.validate()\" because \"aValidation\" is null";
         NotificationHandler handler = NotificationHandler.create();
 
@@ -76,7 +76,7 @@ public class NotificationTest {
     }
 
     @Test
-    public void givenAValidHandler_whenCallAppend_thenShouldReturnNotification() {
+    void givenAValidHandler_whenCallAppend_thenShouldReturnNotification() {
         final var handler = NotificationHandler.create();
         ValidationHandler anotherHandler = new ThrowsValidationHandler();
 

--- a/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/ThrowsValidationHandlerTest.java
+++ b/domain/src/test/java/com/kaua/ecommerce/users/domain/exceptions/ThrowsValidationHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 public class ThrowsValidationHandlerTest {
 
     @Test
-    public void givenAValidError_whenCallAppend_shouldThrowsDomainException() {
+    void givenAValidError_whenCallAppend_shouldThrowsDomainException() {
         Error error = new Error("Sample error");
         ThrowsValidationHandler handler = new ThrowsValidationHandler();
 
@@ -18,7 +18,7 @@ public class ThrowsValidationHandlerTest {
     }
 
     @Test
-    public void givenAValidHandler_whenCallAppend_shouldThrowsDomainException() {
+    void givenAValidHandler_whenCallAppend_shouldThrowsDomainException() {
         ThrowsValidationHandler handler = new ThrowsValidationHandler();
         ValidationHandler anotherHandler = new ThrowsValidationHandler();
 
@@ -26,7 +26,7 @@ public class ThrowsValidationHandlerTest {
     }
 
     @Test
-    public void givenAValidValidation_whenCallValidate_shouldDoesNotThrowException() {
+    void givenAValidValidation_whenCallValidate_shouldDoesNotThrowException() {
         Validation validation = () -> {};
         ThrowsValidationHandler handler = new ThrowsValidationHandler();
 
@@ -34,14 +34,14 @@ public class ThrowsValidationHandlerTest {
     }
 
     @Test
-    public void givenAnInvalidValidation_whenCallValidate_shouldThrowDomainException() {
+    void givenAnInvalidValidation_whenCallValidate_shouldThrowDomainException() {
         ThrowsValidationHandler handler = new ThrowsValidationHandler();
 
         Assertions.assertThrows(DomainException.class, () -> handler.validate(null));
     }
 
     @Test
-    public void testGetErrors() {
+    void testGetErrors() {
         ThrowsValidationHandler handler = new ThrowsValidationHandler();
 
         Assertions.assertEquals(0, handler.getErrors().size());

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/AccountMySQLGateway.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/AccountMySQLGateway.java
@@ -47,6 +47,11 @@ public class AccountMySQLGateway implements AccountGateway {
     }
 
     @Override
+    public Optional<Account> findByEmail(String aEmail) {
+        return this.accountJpaRepository.findByEmail(aEmail).map(AccountJpaEntity::toDomain);
+    }
+
+    @Override
     public Account update(Account aAccount) {
         return this.accountJpaRepository
                 .save(AccountJpaEntity.toEntity(aAccount))

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/models/RequestResetPasswordApiInput.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/models/RequestResetPasswordApiInput.java
@@ -1,0 +1,4 @@
+package com.kaua.ecommerce.users.infrastructure.accounts.models;
+
+public record RequestResetPasswordApiInput(String email) {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/models/ResetPasswordApiInput.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/models/ResetPasswordApiInput.java
@@ -1,0 +1,4 @@
+package com.kaua.ecommerce.users.infrastructure.accounts.models;
+
+public record ResetPasswordApiInput(String password) {
+}

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/persistence/AccountJpaRepository.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/accounts/persistence/AccountJpaRepository.java
@@ -2,7 +2,11 @@ package com.kaua.ecommerce.users.infrastructure.accounts.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AccountJpaRepository extends JpaRepository<AccountJpaEntity, String> {
 
     boolean existsByEmail(String email);
+
+    Optional<AccountJpaEntity> findByEmail(String email);
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
@@ -1,11 +1,11 @@
 package com.kaua.ecommerce.users.infrastructure.api;
 
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
-import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
-import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @RequestMapping(value = "accounts")
 public interface AccountAPI {
@@ -15,10 +15,4 @@ public interface AccountAPI {
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     ResponseEntity<?> createAccount(@RequestBody CreateAccountApiInput input);
-
-    @PostMapping("/request-reset-password")
-    ResponseEntity<?> requestResetPassword(@RequestBody RequestResetPasswordApiInput input);
-
-    @PatchMapping("/reset-password/{token}")
-    ResponseEntity<?> resetPassword(@RequestBody ResetPasswordApiInput input, @PathVariable String token);
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
@@ -1,6 +1,7 @@
 package com.kaua.ecommerce.users.infrastructure.api;
 
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,4 +16,7 @@ public interface AccountAPI {
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     ResponseEntity<?> createAccount(@RequestBody CreateAccountApiInput input);
+
+    @PostMapping("/reset-password")
+    ResponseEntity<?> resetPassword(@RequestBody RequestResetPasswordApiInput input);
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
@@ -2,11 +2,10 @@ package com.kaua.ecommerce.users.infrastructure.api;
 
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
 import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping(value = "accounts")
 public interface AccountAPI {
@@ -19,4 +18,7 @@ public interface AccountAPI {
 
     @PostMapping("/request-reset-password")
     ResponseEntity<?> requestResetPassword(@RequestBody RequestResetPasswordApiInput input);
+
+    @PatchMapping("/reset-password/{token}")
+    ResponseEntity<?> resetPassword(@RequestBody ResetPasswordApiInput input, @PathVariable String token);
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPI.java
@@ -17,6 +17,6 @@ public interface AccountAPI {
     )
     ResponseEntity<?> createAccount(@RequestBody CreateAccountApiInput input);
 
-    @PostMapping("/reset-password")
-    ResponseEntity<?> resetPassword(@RequestBody RequestResetPasswordApiInput input);
+    @PostMapping("/request-reset-password")
+    ResponseEntity<?> requestResetPassword(@RequestBody RequestResetPasswordApiInput input);
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountMailAPI.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/AccountMailAPI.java
@@ -1,17 +1,22 @@
 package com.kaua.ecommerce.users.infrastructure.api;
 
+import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping(value = "accounts/confirm")
+@RequestMapping(value = "accounts")
 public interface AccountMailAPI {
 
-    @PatchMapping("{token}")
+    @PatchMapping("/confirm/{token}")
     ResponseEntity<?> confirmAccount(@PathVariable String token);
 
-    @PostMapping("{accountId}")
+    @PostMapping("/confirm/{accountId}")
     ResponseEntity<?> createAccountConfirmation(@PathVariable String accountId);
+
+    @PostMapping("/request-reset-password")
+    ResponseEntity<?> requestResetPassword(@RequestBody RequestResetPasswordApiInput input);
+
+    @PatchMapping("/reset-password/{token}")
+    ResponseEntity<?> resetPassword(@RequestBody ResetPasswordApiInput input, @PathVariable String token);
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
@@ -2,13 +2,7 @@ package com.kaua.ecommerce.users.infrastructure.api.controllers;
 
 import com.kaua.ecommerce.users.application.account.create.CreateAccountCommand;
 import com.kaua.ecommerce.users.application.account.create.CreateAccountUseCase;
-import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordCommand;
-import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
-import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordCommand;
-import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordUseCase;
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
-import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
-import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import com.kaua.ecommerce.users.infrastructure.api.AccountAPI;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,17 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController implements AccountAPI {
 
     private final CreateAccountUseCase createAccountUseCase;
-    private final RequestResetPasswordUseCase requestResetPasswordUseCase;
-    private final ResetPasswordUseCase resetPasswordUseCase;
 
-    public AccountController(
-            final CreateAccountUseCase createAccountUseCase,
-            final RequestResetPasswordUseCase requestResetPasswordUseCase,
-            final ResetPasswordUseCase resetPasswordUseCase
-    ) {
+    public AccountController(final CreateAccountUseCase createAccountUseCase) {
         this.createAccountUseCase = createAccountUseCase;
-        this.requestResetPasswordUseCase = requestResetPasswordUseCase;
-        this.resetPasswordUseCase = resetPasswordUseCase;
     }
 
     @Override
@@ -45,21 +31,5 @@ public class AccountController implements AccountAPI {
         return aResult.isLeft()
                 ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
                 : ResponseEntity.status(HttpStatus.CREATED).body(aResult.getRight());
-    }
-
-    @Override
-    public ResponseEntity<?> requestResetPassword(RequestResetPasswordApiInput input) {
-        this.requestResetPasswordUseCase.execute(RequestResetPasswordCommand.with(input.email()));
-        return ResponseEntity.noContent().build();
-    }
-
-    @Override
-    public ResponseEntity<?> resetPassword(ResetPasswordApiInput input, String token) {
-        final var aResult = this.resetPasswordUseCase.execute(ResetPasswordCommand
-                .with(input.password(), token));
-
-        return aResult.isLeft()
-                ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
-                : ResponseEntity.noContent().build();
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
@@ -42,7 +42,7 @@ public class AccountController implements AccountAPI {
     }
 
     @Override
-    public ResponseEntity<?> resetPassword(RequestResetPasswordApiInput input) {
+    public ResponseEntity<?> requestResetPassword(RequestResetPasswordApiInput input) {
         this.requestResetPasswordUseCase.execute(RequestResetPasswordCommand.with(input.email()));
         return ResponseEntity.noContent().build();
     }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
@@ -4,8 +4,11 @@ import com.kaua.ecommerce.users.application.account.create.CreateAccountCommand;
 import com.kaua.ecommerce.users.application.account.create.CreateAccountUseCase;
 import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordCommand;
 import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordCommand;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordUseCase;
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
 import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import com.kaua.ecommerce.users.infrastructure.api.AccountAPI;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,13 +19,16 @@ public class AccountController implements AccountAPI {
 
     private final CreateAccountUseCase createAccountUseCase;
     private final RequestResetPasswordUseCase requestResetPasswordUseCase;
+    private final ResetPasswordUseCase resetPasswordUseCase;
 
     public AccountController(
             final CreateAccountUseCase createAccountUseCase,
-            final RequestResetPasswordUseCase requestResetPasswordUseCase
+            final RequestResetPasswordUseCase requestResetPasswordUseCase,
+            final ResetPasswordUseCase resetPasswordUseCase
     ) {
         this.createAccountUseCase = createAccountUseCase;
         this.requestResetPasswordUseCase = requestResetPasswordUseCase;
+        this.resetPasswordUseCase = resetPasswordUseCase;
     }
 
     @Override
@@ -45,5 +51,15 @@ public class AccountController implements AccountAPI {
     public ResponseEntity<?> requestResetPassword(RequestResetPasswordApiInput input) {
         this.requestResetPasswordUseCase.execute(RequestResetPasswordCommand.with(input.email()));
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<?> resetPassword(ResetPasswordApiInput input, String token) {
+        final var aResult = this.resetPasswordUseCase.execute(ResetPasswordCommand
+                .with(input.password(), token));
+
+        return aResult.isLeft()
+                ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
+                : ResponseEntity.noContent().build();
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountController.java
@@ -2,7 +2,10 @@ package com.kaua.ecommerce.users.infrastructure.api.controllers;
 
 import com.kaua.ecommerce.users.application.account.create.CreateAccountCommand;
 import com.kaua.ecommerce.users.application.account.create.CreateAccountUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordCommand;
+import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
 import com.kaua.ecommerce.users.infrastructure.api.AccountAPI;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,9 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController implements AccountAPI {
 
     private final CreateAccountUseCase createAccountUseCase;
+    private final RequestResetPasswordUseCase requestResetPasswordUseCase;
 
-    public AccountController(final CreateAccountUseCase createAccountUseCase) {
+    public AccountController(
+            final CreateAccountUseCase createAccountUseCase,
+            final RequestResetPasswordUseCase requestResetPasswordUseCase
+    ) {
         this.createAccountUseCase = createAccountUseCase;
+        this.requestResetPasswordUseCase = requestResetPasswordUseCase;
     }
 
     @Override
@@ -31,5 +39,11 @@ public class AccountController implements AccountAPI {
         return aResult.isLeft()
                 ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
                 : ResponseEntity.status(HttpStatus.CREATED).body(aResult.getRight());
+    }
+
+    @Override
+    public ResponseEntity<?> resetPassword(RequestResetPasswordApiInput input) {
+        this.requestResetPasswordUseCase.execute(RequestResetPasswordCommand.with(input.email()));
+        return ResponseEntity.noContent().build();
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountMailController.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/api/controllers/AccountMailController.java
@@ -4,9 +4,15 @@ import com.kaua.ecommerce.users.application.account.mail.confirm.ConfirmAccountM
 import com.kaua.ecommerce.users.application.account.mail.confirm.ConfirmAccountMailUseCase;
 import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailCommand;
 import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordCommand;
+import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordCommand;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordUseCase;
 import com.kaua.ecommerce.users.domain.accounts.mail.AccountMailType;
 import com.kaua.ecommerce.users.domain.utils.IdUtils;
 import com.kaua.ecommerce.users.domain.utils.InstantUtils;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import com.kaua.ecommerce.users.infrastructure.api.AccountMailAPI;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,13 +25,19 @@ public class AccountMailController implements AccountMailAPI {
 
     private final CreateAccountMailUseCase createAccountMailUseCase;
     private final ConfirmAccountMailUseCase confirmAccountMailUseCase;
+    private final RequestResetPasswordUseCase requestResetPasswordUseCase;
+    private final ResetPasswordUseCase resetPasswordUseCase;
 
     public AccountMailController(
             final CreateAccountMailUseCase createAccountMailUseCase,
-            final ConfirmAccountMailUseCase confirmAccountMailUseCase
+            final ConfirmAccountMailUseCase confirmAccountMailUseCase,
+            final RequestResetPasswordUseCase requestResetPasswordUseCase,
+            final ResetPasswordUseCase resetPasswordUseCase
     ) {
         this.createAccountMailUseCase = createAccountMailUseCase;
         this.confirmAccountMailUseCase = confirmAccountMailUseCase;
+        this.requestResetPasswordUseCase = requestResetPasswordUseCase;
+        this.resetPasswordUseCase = resetPasswordUseCase;
     }
 
     @Override
@@ -53,5 +65,21 @@ public class AccountMailController implements AccountMailAPI {
         return aResult.isLeft()
                 ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
                 : ResponseEntity.status(HttpStatus.CREATED).body(aResult.getRight());
+    }
+
+    @Override
+    public ResponseEntity<?> requestResetPassword(RequestResetPasswordApiInput input) {
+        this.requestResetPasswordUseCase.execute(RequestResetPasswordCommand.with(input.email()));
+        return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<?> resetPassword(ResetPasswordApiInput input, String token) {
+        final var aResult = this.resetPasswordUseCase.execute(ResetPasswordCommand
+                .with(token, input.password()));
+
+        return aResult.isLeft()
+                ? ResponseEntity.unprocessableEntity().body(aResult.getLeft())
+                : ResponseEntity.noContent().build();
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/configurations/usecases/AccountMailUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/configurations/usecases/AccountMailUseCaseConfig.java
@@ -6,8 +6,11 @@ import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMai
 import com.kaua.ecommerce.users.application.account.mail.create.DefaultCreateAccountMailUseCase;
 import com.kaua.ecommerce.users.application.account.update.password.DefaultRequestResetPasswordUseCase;
 import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.reset.DefaultResetPasswordUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordUseCase;
 import com.kaua.ecommerce.users.application.gateways.AccountGateway;
 import com.kaua.ecommerce.users.application.gateways.AccountMailGateway;
+import com.kaua.ecommerce.users.application.gateways.EncrypterGateway;
 import com.kaua.ecommerce.users.application.gateways.QueueGateway;
 import com.kaua.ecommerce.users.infrastructure.configurations.annotations.EmailQueue;
 import org.springframework.context.annotation.Bean;
@@ -21,15 +24,18 @@ public class AccountMailUseCaseConfig {
     private final AccountMailGateway accountMailGateway;
     private final AccountGateway accountGateway;
     private final QueueGateway queueGateway;
+    private final EncrypterGateway encrypterGateway;
 
     public AccountMailUseCaseConfig(
             final AccountMailGateway accountMailGateway,
             final AccountGateway accountGateway,
-            @EmailQueue final QueueGateway queueGateway
+            @EmailQueue final QueueGateway queueGateway,
+            final EncrypterGateway encrypterGateway
     ) {
         this.accountMailGateway = Objects.requireNonNull(accountMailGateway);
         this.accountGateway = Objects.requireNonNull(accountGateway);
         this.queueGateway = Objects.requireNonNull(queueGateway);
+        this.encrypterGateway = Objects.requireNonNull(encrypterGateway);
     }
 
     @Bean
@@ -45,5 +51,10 @@ public class AccountMailUseCaseConfig {
     @Bean
     public RequestResetPasswordUseCase requestResetPasswordUseCase() {
         return new DefaultRequestResetPasswordUseCase(accountGateway, createAccountMailUseCase());
+    }
+
+    @Bean
+    public ResetPasswordUseCase resetPasswordUseCase() {
+        return new DefaultResetPasswordUseCase(accountGateway, encrypterGateway, accountMailGateway);
     }
 }

--- a/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/configurations/usecases/AccountMailUseCaseConfig.java
+++ b/infrastructure/src/main/java/com/kaua/ecommerce/users/infrastructure/configurations/usecases/AccountMailUseCaseConfig.java
@@ -4,6 +4,8 @@ import com.kaua.ecommerce.users.application.account.mail.confirm.ConfirmAccountM
 import com.kaua.ecommerce.users.application.account.mail.confirm.DefaultConfirmAccountMailUseCase;
 import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailUseCase;
 import com.kaua.ecommerce.users.application.account.mail.create.DefaultCreateAccountMailUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.DefaultRequestResetPasswordUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
 import com.kaua.ecommerce.users.application.gateways.AccountGateway;
 import com.kaua.ecommerce.users.application.gateways.AccountMailGateway;
 import com.kaua.ecommerce.users.application.gateways.QueueGateway;
@@ -38,5 +40,10 @@ public class AccountMailUseCaseConfig {
     @Bean
     public ConfirmAccountMailUseCase confirmAccountMailUseCase() {
         return new DefaultConfirmAccountMailUseCase(accountMailGateway, accountGateway);
+    }
+
+    @Bean
+    public RequestResetPasswordUseCase requestResetPasswordUseCase() {
+        return new DefaultRequestResetPasswordUseCase(accountGateway, createAccountMailUseCase());
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/application/account/create/CreateAccountUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/application/account/create/CreateAccountUseCaseIT.java
@@ -27,7 +27,7 @@ public class CreateAccountUseCaseIT {
     private AccountGateway accountGateway;
 
     @Test
-    public void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() {
+    void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -60,7 +60,7 @@ public class CreateAccountUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidFirstName_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidFirstName_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "";
         final var aLastName = "Silveira";
@@ -85,7 +85,7 @@ public class CreateAccountUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidLastName_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidLastName_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final String aLastName = null;
@@ -110,7 +110,7 @@ public class CreateAccountUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidEmail_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidEmail_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -135,7 +135,7 @@ public class CreateAccountUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidPassword_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnInvalidPassword_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -160,7 +160,7 @@ public class CreateAccountUseCaseIT {
     }
 
     @Test
-    public void givenAnExistingEmail_whenCallCreateAccount_thenShouldReturnAnError() {
+    void givenAnExistingEmail_whenCallCreateAccount_thenShouldReturnAnError() {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/application/account/mail/confirm/ConfirmAccountMailUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/application/account/mail/confirm/ConfirmAccountMailUseCaseIT.java
@@ -36,7 +36,7 @@ public class ConfirmAccountMailUseCaseIT {
     private AccountMailGateway accountMailGateway;
 
     @Test
-    public void givenAValidCommand_whenCallConfirmAccount_thenShouldReturneTrue() {
+    void givenAValidCommand_whenCallConfirmAccount_thenShouldReturneTrue() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -66,7 +66,7 @@ public class ConfirmAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidToken_whenCallCreateAccountMail_thenShouldReturneAnError() {
+    void givenAnInvalidToken_whenCallCreateAccountMail_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -84,7 +84,7 @@ public class ConfirmAccountMailUseCaseIT {
 
         // when
         final var aOutput = Assertions.assertThrows(NotFoundException.class,
-                () -> useCase.execute(aCommand).getLeft());
+                () -> useCase.execute(aCommand));
 
         // then
         Assertions.assertEquals(expectedErrorMessage, aOutput.getMessage());
@@ -92,7 +92,7 @@ public class ConfirmAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAValidCommandButExpiredToken_whenCallConfirmAccount_thenShouldReturneAnError() {
+    void givenAValidCommandButExpiredToken_whenCallConfirmAccount_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/application/account/mail/create/CreateAccountMailUseCaseIT.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/application/account/mail/create/CreateAccountMailUseCaseIT.java
@@ -34,7 +34,7 @@ public class CreateAccountMailUseCaseIT {
     private AccountMailGateway accountMailGateway;
 
     @Test
-    public void givenAValidCommand_whenCallCreateAccountMail_thenShouldReturneAnAccountMail() {
+    void givenAValidCommand_whenCallCreateAccountMail_thenShouldReturneAnAccountMail() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -79,7 +79,7 @@ public class CreateAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidToken_whenCallCreateAccountMail_thenShouldReturneAnError() {
+    void givenAnInvalidToken_whenCallCreateAccountMail_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -113,7 +113,7 @@ public class CreateAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidTokenLengthMoreThan36_whenCallCreateAccountMail_thenShouldReturneAnError() {
+    void givenAnInvalidTokenLengthMoreThan36_whenCallCreateAccountMail_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -147,7 +147,7 @@ public class CreateAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidType_whenCallCreateAccountMail_thenShouldReturneAnError() {
+    void givenAnInvalidType_whenCallCreateAccountMail_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -181,7 +181,7 @@ public class CreateAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidExpiresAt_whenCallCreateAccountMail_thenShouldReturneAnError() {
+    void givenAnInvalidExpiresAt_whenCallCreateAccountMail_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",
@@ -215,7 +215,7 @@ public class CreateAccountMailUseCaseIT {
     }
 
     @Test
-    public void givenAnInvalidExpiresAtBeforeNow_whenCallCreateAccountMail_thenShouldReturneAnError() {
+    void givenAnInvalidExpiresAtBeforeNow_whenCallCreateAccountMail_thenShouldReturneAnError() {
         // given
         final var aAccount = Account.newAccount(
                 "Fulano",

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/AccountMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/AccountMySQLGatewayTest.java
@@ -110,7 +110,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidAccountIdNotStored_whenCallFindById_shouldReturnEmpty() {
+    public void givenAValidAccountIdButNotStored_whenCallFindById_shouldReturnEmpty() {
         Assertions.assertEquals(0, accountRepository.count());
 
         final var actualAccount = accountGateway.findById(AccountID.from("empty").getValue());
@@ -159,5 +159,42 @@ public class AccountMySQLGatewayTest {
         Assertions.assertEquals(aAccount.getMailStatus(), actualEntity.getMailStatus());
         Assertions.assertEquals(aAccount.getCreatedAt(), actualEntity.getCreatedAt());
         Assertions.assertEquals(aAccount.getUpdatedAt(), actualEntity.getUpdatedAt());
+    }
+
+    @Test
+    public void givenAPrePersistedAccountAndValidEmail_whenCallFindByEmail_shouldReturnAccount() {
+        final var aFirstName = "Fulano";
+        final var aLastName = "Silva";
+        final var aEmail = "teste@teste.com";
+        final var aPassword = "1234567Ab";
+
+        Account aAccount = Account.newAccount(aFirstName, aLastName, aEmail, aPassword);
+
+        Assertions.assertEquals(0, accountRepository.count());
+
+        accountRepository.save(AccountJpaEntity.toEntity(aAccount));
+
+        Assertions.assertEquals(1, accountRepository.count());
+
+        final var actualAccount = accountGateway.findByEmail(aEmail).get();
+
+        Assertions.assertEquals(aAccount.getId(), actualAccount.getId());
+        Assertions.assertEquals(aFirstName, actualAccount.getFirstName());
+        Assertions.assertEquals(aLastName, actualAccount.getLastName());
+        Assertions.assertEquals(aEmail, actualAccount.getEmail());
+        Assertions.assertEquals(aPassword, actualAccount.getPassword());
+        Assertions.assertNull(actualAccount.getAvatarUrl());
+        Assertions.assertEquals(aAccount.getMailStatus(), actualAccount.getMailStatus());
+        Assertions.assertEquals(aAccount.getCreatedAt(), actualAccount.getCreatedAt());
+        Assertions.assertEquals(aAccount.getUpdatedAt(), actualAccount.getUpdatedAt());
+    }
+
+    @Test
+    public void givenAnInvalidEmailNotStored_whenCallFindByEmail_shouldReturnEmpty() {
+        Assertions.assertEquals(0, accountRepository.count());
+
+        final var actualAccount = accountGateway.findByEmail("empty");
+
+        Assertions.assertTrue(actualAccount.isEmpty());
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/AccountMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/AccountMySQLGatewayTest.java
@@ -20,7 +20,7 @@ public class AccountMySQLGatewayTest {
     private AccountJpaRepository accountRepository;
 
     @Test
-    public void givenAValidAccount_whenCallCreate_shouldReturnANewAccount() {
+    void givenAValidAccount_whenCallCreate_shouldReturnANewAccount() {
         final var aFirstName = "Fulano";
         final var aLastName = "Silva";
         final var aEmail = "teste@teste.com";
@@ -58,7 +58,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidEmailButNotExistis_whenCallExistsByEmail_shouldReturnFalse() {
+    void givenAValidEmailButNotExistis_whenCallExistsByEmail_shouldReturnFalse() {
         final var aEmail = "teste@teste.com";
 
         Assertions.assertEquals(0, accountRepository.count());
@@ -66,7 +66,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidExistingEmail_whenCallExistsByEmail_shouldReturnTrue() {
+    void givenAValidExistingEmail_whenCallExistsByEmail_shouldReturnTrue() {
         final var aFirstName = "Fulano";
         final var aLastName = "Silva";
         final var aEmail = "teste@teste.com";
@@ -82,7 +82,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAPrePersistedAccountAndValidAccountId_whenCallFindById_shouldReturnAccount() {
+    void givenAPrePersistedAccountAndValidAccountId_whenCallFindById_shouldReturnAccount() {
         final var aFirstName = "Fulano";
         final var aLastName = "Silva";
         final var aEmail = "teste@teste.com";
@@ -110,7 +110,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidAccountIdButNotStored_whenCallFindById_shouldReturnEmpty() {
+    void givenAValidAccountIdButNotStored_whenCallFindById_shouldReturnEmpty() {
         Assertions.assertEquals(0, accountRepository.count());
 
         final var actualAccount = accountGateway.findById(AccountID.from("empty").getValue());
@@ -119,7 +119,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidAccount_whenCallUpdate_shouldReturnAUpdatedAccount() {
+    void givenAValidAccount_whenCallUpdate_shouldReturnAUpdatedAccount() {
         final var aFirstName = "Fulano";
         final var aLastName = "Silva";
         final var aEmail = "teste@teste.com";
@@ -162,7 +162,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAPrePersistedAccountAndValidEmail_whenCallFindByEmail_shouldReturnAccount() {
+    void givenAPrePersistedAccountAndValidEmail_whenCallFindByEmail_shouldReturnAccount() {
         final var aFirstName = "Fulano";
         final var aLastName = "Silva";
         final var aEmail = "teste@teste.com";
@@ -190,7 +190,7 @@ public class AccountMySQLGatewayTest {
     }
 
     @Test
-    public void givenAnInvalidEmailNotStored_whenCallFindByEmail_shouldReturnEmpty() {
+    void givenAnInvalidEmailNotStored_whenCallFindByEmail_shouldReturnEmpty() {
         Assertions.assertEquals(0, accountRepository.count());
 
         final var actualAccount = accountGateway.findByEmail("empty");

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/mail/AccountMailMySQLGatewayTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/mail/AccountMailMySQLGatewayTest.java
@@ -40,7 +40,7 @@ public class AccountMailMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidAccountMail_whenCallCreate_shouldReturnANewAccountMail() {
+    void givenAValidAccountMail_whenCallCreate_shouldReturnANewAccountMail() {
         final var aToken = RandomStringUtils.generateValue(36);
         final var aType = AccountMailType.ACCOUNT_CONFIRMATION;
         final var aAccount = Account.newAccount(
@@ -86,7 +86,7 @@ public class AccountMailMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidPrePersistedAccountMails_whenCallFindAllByAccountId_shouldReturnAListOfAccountMail() {
+    void givenAValidPrePersistedAccountMails_whenCallFindAllByAccountId_shouldReturnAListOfAccountMail() {
         final var expectedMailsCount = 2;
 
         final var aAccount = Account.newAccount(
@@ -122,7 +122,7 @@ public class AccountMailMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidPrePersistedAccountMail_whenCallDeleteById_shouldDoesNotThrowException() {
+    void givenAValidPrePersistedAccountMail_whenCallDeleteById_shouldDoesNotThrowException() {
         final var aAccount = Account.newAccount(
                 "Fulano",
                 "Silva",
@@ -150,7 +150,7 @@ public class AccountMailMySQLGatewayTest {
     }
 
     @Test
-    public void givenInvalidAccountMailId_whenCallDeleteById_shouldDeleteAccountMail() {
+    void givenInvalidAccountMailId_whenCallDeleteById_shouldDeleteAccountMail() {
         Assertions.assertEquals(0, accountMailRepository.count());
 
         accountMailGateway.deleteById(AccountMailID.from("empty").getValue());
@@ -159,7 +159,7 @@ public class AccountMailMySQLGatewayTest {
     }
 
     @Test
-    public void givenAValidPrePersistedAccountMail_whenCallFindByToken_shouldReturnAccountMail() {
+    void givenAValidPrePersistedAccountMail_whenCallFindByToken_shouldReturnAccountMail() {
         final var aAccount = Account.newAccount(
                 "Fulano",
                 "Silva",

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/mail/persistence/AccountMailRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/mail/persistence/AccountMailRepositoryTest.java
@@ -31,7 +31,7 @@ public class AccountMailRepositoryTest {
     private AccountJpaRepository accountJpaRepository;
 
     @Test
-    public void givenAnInvalidNullToken_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullToken_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "token";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity.token";
 
@@ -64,7 +64,7 @@ public class AccountMailRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullType_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullType_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "type";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity.type";
 
@@ -97,7 +97,7 @@ public class AccountMailRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullExpiresAt_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullExpiresAt_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "expiresAt";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity.expiresAt";
 
@@ -130,7 +130,7 @@ public class AccountMailRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullAccount_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullAccount_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "account";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity.account";
 
@@ -163,7 +163,7 @@ public class AccountMailRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullCreatedAt_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullCreatedAt_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "createdAt";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity.createdAt";
 
@@ -196,7 +196,7 @@ public class AccountMailRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullUpdatedAt_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullUpdatedAt_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "updatedAt";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity.updatedAt";
 
@@ -229,7 +229,7 @@ public class AccountMailRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
         final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.users.infrastructure.accounts.mail.persistence.AccountMailJpaEntity";
 
         final var aAccount = Account.newAccount(

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/persistence/AccountRepositoryTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/account/persistence/AccountRepositoryTest.java
@@ -20,7 +20,7 @@ public class AccountRepositoryTest {
     private AccountJpaRepository accountRepository;
 
     @Test
-    public void givenAnInvalidNullFirstName_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullFirstName_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "firstName";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.firstName";
 
@@ -44,7 +44,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullLastName_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullLastName_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "lastName";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.lastName";
 
@@ -68,7 +68,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullEmail_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullEmail_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "email";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.email";
 
@@ -92,7 +92,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullPassword_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullPassword_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "password";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.password";
 
@@ -116,7 +116,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullMailStatus_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullMailStatus_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "mailStatus";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.mailStatus";
 
@@ -140,7 +140,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullCreatedAt_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullCreatedAt_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "createdAt";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.createdAt";
 
@@ -164,7 +164,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullUpdatedAt_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullUpdatedAt_whenCallSave_shouldReturnAnException() {
         final var expectedPropertyName = "updatedAt";
         final var expectedErrorMessage = "not-null property references a null or transient value : com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity.updatedAt";
 
@@ -188,7 +188,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
+    void givenAnInvalidNullId_whenCallSave_shouldReturnAnException() {
         final var expectedErrorMessage = "ids for this class must be manually assigned before calling save(): com.kaua.ecommerce.users.infrastructure.accounts.persistence.AccountJpaEntity";
 
         final var aAccount = Account.newAccount(
@@ -210,7 +210,7 @@ public class AccountRepositoryTest {
     }
 
     @Test
-    public void givenAValidAvatarUrl_whenCallSave_shouldDoesNotThrowException() {
+    void givenAValidAvatarUrl_whenCallSave_shouldDoesNotThrowException() {
         final var aAccount = Account.newAccount(
                 "Fulano",
                 "Silva",

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/amqp/AccountCreatedListenerTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/amqp/AccountCreatedListenerTest.java
@@ -39,7 +39,7 @@ public class AccountCreatedListenerTest {
     private QueueProperties queueProperties;
 
     @Test
-    public void givenAccount_whenCallsListener_shouldCallUseCase() throws InterruptedException {
+    void givenAccount_whenCallsListener_shouldCallUseCase() throws InterruptedException {
         final var aAccount = Account.newAccount(
                 "teste",
                 "testes",

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPITest.java
@@ -5,24 +5,18 @@ import com.kaua.ecommerce.users.ControllerTest;
 import com.kaua.ecommerce.users.application.account.create.CreateAccountCommand;
 import com.kaua.ecommerce.users.application.account.create.CreateAccountOutput;
 import com.kaua.ecommerce.users.application.account.create.CreateAccountUseCase;
-import com.kaua.ecommerce.users.application.account.mail.confirm.ConfirmAccountMailCommand;
 import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
-import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordCommand;
 import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordUseCase;
 import com.kaua.ecommerce.users.application.either.Either;
-import com.kaua.ecommerce.users.domain.exceptions.NotFoundException;
 import com.kaua.ecommerce.users.domain.utils.RandomStringUtils;
 import com.kaua.ecommerce.users.domain.validation.Error;
 import com.kaua.ecommerce.users.domain.validation.handler.NotificationHandler;
 import com.kaua.ecommerce.users.infrastructure.accounts.models.CreateAccountApiInput;
-import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
-import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -51,9 +45,6 @@ public class AccountAPITest {
 
     @MockBean
     private ResetPasswordUseCase resetPasswordUseCase;
-
-    @MockBean
-    private BCryptPasswordEncoder passwordEncoder;
 
     @Test
     public void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() throws Exception {
@@ -440,93 +431,5 @@ public class AccountAPITest {
                         Objects.equals(aEmail, cmd.email()) &&
                         Objects.equals(aPassword, cmd.password())
         ));
-    }
-
-    @Test
-    public void givenAValidCommand_whenCallRequestResetPassword_thenShouldReturnNotContent() throws Exception {
-        // given
-        final var aEmail = "teste@teste.com";
-
-        final var aInput = new RequestResetPasswordApiInput(aEmail);
-
-        final var request = MockMvcRequestBuilders.post("/accounts/request-reset-password")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(this.mapper.writeValueAsString(aInput));
-
-        this.mvc.perform(request)
-                .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isNoContent());
-
-        Mockito.verify(requestResetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
-                Objects.equals(aEmail, cmd.email())
-        ));
-    }
-
-    @Test
-    public void givenAInvalidCommandEmailNotFound_whenCallRequestResetPassword_thenShouldThrowNotFoundException() throws Exception {
-        // given
-        final var aEmail = "teste@teste.com";
-
-        final var aInput = new RequestResetPasswordApiInput(aEmail);
-
-        Mockito.doThrow(NotFoundException.class)
-                .when(requestResetPasswordUseCase).execute(Mockito.any());
-
-        final var request = MockMvcRequestBuilders.post("/accounts/request-reset-password")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(this.mapper.writeValueAsString(aInput));
-
-        this.mvc.perform(request)
-                .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isNotFound());
-
-        Mockito.verify(requestResetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
-                Objects.equals(aEmail, cmd.email())
-        ));
-    }
-
-    @Test
-    public void givenAValidCommand_whenCallResetPassword_thenShouldReturneNoContent() throws Exception {
-        // given
-        final var aToken = RandomStringUtils.generateValue(36);
-        final var aPassword = "1234567Ab*";
-
-        final var aInput = new ResetPasswordApiInput(aPassword);
-
-        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
-                .thenReturn(Either.right(true));
-
-        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(this.mapper.writeValueAsString(aInput));
-
-        this.mvc.perform(request)
-                .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isNoContent());
-    }
-
-    @Test
-    public void givenAnInvalidTokenExpired_whenCallResetPassword_thenShouldReturneAnError() throws Exception {
-        // given
-        final var expectedErrorMessage = "Token expired";
-        final var aToken = RandomStringUtils.generateValue(36);
-        final var aPassword = "1234567Ab*";
-
-        final var aInput = new ResetPasswordApiInput(aPassword);
-
-        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
-                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
-
-        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
-                .accept(MediaType.APPLICATION_JSON)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(this.mapper.writeValueAsString(aInput));
-
-        this.mvc.perform(request)
-                .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
-                .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountAPITest.java
@@ -47,7 +47,7 @@ public class AccountAPITest {
     private ResetPasswordUseCase resetPasswordUseCase;
 
     @Test
-    public void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() throws Exception {
+    void givenAValidCommand_whenCallCreateAccount_thenShouldReturneAnAccountId() throws Exception {
         // given
         final var aFirstName = "Fulano";
         final var aLastName = "Silveira";
@@ -82,7 +82,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandFirstName_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandFirstName_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final String aFirstName = null;
         final var aLastName = "Silveira";
         final var aEmail = "teste@teste.com";
@@ -114,7 +114,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandFirstNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandFirstNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "te";
         final var aLastName = "Silveira";
         final var aEmail = "teste@teste.com";
@@ -146,7 +146,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandFirstNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandFirstNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = RandomStringUtils.generateValue(256);
         final var aLastName = "Silveira";
         final var aEmail = "teste@teste.com";
@@ -178,7 +178,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandLastName_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandLastName_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "Teste";
         final var aLastName = "";
         final var aEmail = "teste@teste.com";
@@ -210,7 +210,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandLastNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandLastNameLengthLessThan3_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "teste";
         final var aLastName = "Te";
         final var aEmail = "teste@teste.com";
@@ -242,7 +242,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandLastNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandLastNameLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "teste";
         final var aLastName = RandomStringUtils.generateValue(256);
         final var aEmail = "teste@teste.com";
@@ -274,7 +274,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandEmail_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandEmail_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "Teste";
         final var aLastName = "testes";
         final var aEmail = "";
@@ -306,7 +306,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandPassword_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandPassword_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "Teste";
         final var aLastName = "testes";
         final var aEmail = "teste@teste.com";
@@ -338,7 +338,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "teste";
         final var aLastName = "Testes";
         final var aEmail = "teste@teste.com";
@@ -370,7 +370,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "teste";
         final var aLastName = "testes";
         final var aEmail = "teste@teste.com";
@@ -402,7 +402,7 @@ public class AccountAPITest {
     }
 
     @Test
-    public void givenAnInvalidCommandPasswordNotContainsOneUppercaseAndLowercaseLetter_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+    void givenAnInvalidCommandPasswordNotContainsOneUppercaseAndLowercaseLetter_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
         final var aFirstName = "teste";
         final var aLastName = "testes";
         final var aEmail = "teste@teste.com";

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountMailAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountMailAPITest.java
@@ -357,4 +357,116 @@ public class AccountMailAPITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
     }
+
+    @Test
+    public void givenAnInvalidCommandPassword_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+        final var aToken = RandomStringUtils.generateValue(36);
+        final String aPassword = null;
+        final var expectedErrorMessage = "'password' should not be null or blank";
+
+        final var aInput = new ResetPasswordApiInput(aPassword);
+
+        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(MockMvcResultMatchers.header().string("Content-Type", MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
+
+        Mockito.verify(resetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
+                Objects.equals(aToken, cmd.token()) &&
+                        Objects.isNull(cmd.newPassword())
+        ));
+    }
+
+    @Test
+    public void givenAnInvalidCommandPasswordLengthLessThan8_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aPassword = "123";
+        final var expectedErrorMessage = "'password' must be between 8 and 255 characters";
+
+        final var aInput = new ResetPasswordApiInput(aPassword);
+
+        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(MockMvcResultMatchers.header().string("Content-Type", MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
+
+        Mockito.verify(resetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
+                Objects.equals(aToken, cmd.token()) &&
+                        Objects.equals(aPassword, cmd.newPassword())
+        ));
+    }
+
+    @Test
+    public void givenAnInvalidCommandPasswordLengthMoreThan255_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aPassword = RandomStringUtils.generateValue(256).toLowerCase();
+        final var expectedErrorMessage = "'password' must be between 3 and 255 characters";
+
+        final var aInput = new ResetPasswordApiInput(aPassword);
+
+        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(MockMvcResultMatchers.header().string("Content-Type", MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
+
+        Mockito.verify(resetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
+                Objects.equals(aToken, cmd.token()) &&
+                        Objects.equals(aPassword, cmd.newPassword())
+        ));
+    }
+
+    @Test
+    public void givenAnInvalidCommandPasswordNotContainsOneUppercaseAndLowercaseLetter_whenCallCreateAccount_thenShouldReturnDomainException() throws Exception {
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aPassword = "12345678";
+        final var expectedErrorMessage = "'password' should contain at least one uppercase letter, one lowercase letter and one number";
+
+        final var aInput = new ResetPasswordApiInput(aPassword);
+
+        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(MockMvcResultMatchers.header().string("Content-Type", MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
+
+        Mockito.verify(resetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
+                Objects.equals(aToken, cmd.token()) &&
+                        Objects.equals(aPassword, cmd.newPassword())
+        ));
+    }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountMailAPITest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/api/AccountMailAPITest.java
@@ -6,6 +6,9 @@ import com.kaua.ecommerce.users.application.account.mail.confirm.ConfirmAccountM
 import com.kaua.ecommerce.users.application.account.mail.confirm.ConfirmAccountMailUseCase;
 import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailOutput;
 import com.kaua.ecommerce.users.application.account.mail.create.CreateAccountMailUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.RequestResetPasswordUseCase;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordCommand;
+import com.kaua.ecommerce.users.application.account.update.password.reset.ResetPasswordUseCase;
 import com.kaua.ecommerce.users.application.either.Either;
 import com.kaua.ecommerce.users.domain.accounts.Account;
 import com.kaua.ecommerce.users.domain.exceptions.DomainException;
@@ -13,6 +16,8 @@ import com.kaua.ecommerce.users.domain.exceptions.NotFoundException;
 import com.kaua.ecommerce.users.domain.utils.RandomStringUtils;
 import com.kaua.ecommerce.users.domain.validation.Error;
 import com.kaua.ecommerce.users.domain.validation.handler.NotificationHandler;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.RequestResetPasswordApiInput;
+import com.kaua.ecommerce.users.infrastructure.accounts.models.ResetPasswordApiInput;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,8 +28,11 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.Objects;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.argThat;
 
 @ControllerTest(controllers = AccountMailAPI.class)
 public class AccountMailAPITest {
@@ -40,6 +48,12 @@ public class AccountMailAPITest {
 
     @MockBean
     private ConfirmAccountMailUseCase confirmAccountMailUseCase;
+
+    @MockBean
+    private RequestResetPasswordUseCase requestResetPasswordUseCase;
+
+    @MockBean
+    private ResetPasswordUseCase resetPasswordUseCase;
 
     @Test
     public void givenAValidCommand_whenCallConfirmAccount_thenShouldReturneNoContent() throws Exception {
@@ -254,5 +268,93 @@ public class AccountMailAPITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message", equalTo(expectedErrorMessage)));
 
         Mockito.verify(createAccountMailUseCase, Mockito.times(1)).execute(Mockito.any());
+    }
+
+    @Test
+    public void givenAValidCommand_whenCallRequestResetPassword_thenShouldReturnNotContent() throws Exception {
+        // given
+        final var aEmail = "teste@teste.com";
+
+        final var aInput = new RequestResetPasswordApiInput(aEmail);
+
+        final var request = MockMvcRequestBuilders.post("/accounts/request-reset-password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        Mockito.verify(requestResetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
+                Objects.equals(aEmail, cmd.email())
+        ));
+    }
+
+    @Test
+    public void givenAInvalidCommandEmailNotFound_whenCallRequestResetPassword_thenShouldThrowNotFoundException() throws Exception {
+        // given
+        final var aEmail = "teste@teste.com";
+
+        final var aInput = new RequestResetPasswordApiInput(aEmail);
+
+        Mockito.doThrow(NotFoundException.class)
+                .when(requestResetPasswordUseCase).execute(Mockito.any());
+
+        final var request = MockMvcRequestBuilders.post("/accounts/request-reset-password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+
+        Mockito.verify(requestResetPasswordUseCase, Mockito.times(1)).execute(argThat(cmd ->
+                Objects.equals(aEmail, cmd.email())
+        ));
+    }
+
+    @Test
+    public void givenAValidCommand_whenCallResetPassword_thenShouldReturneNoContent() throws Exception {
+        // given
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aPassword = "1234567Ab*";
+
+        final var aInput = new ResetPasswordApiInput(aPassword);
+
+        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
+                .thenReturn(Either.right(true));
+
+        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+
+    @Test
+    public void givenAnInvalidTokenExpired_whenCallResetPassword_thenShouldReturneAnError() throws Exception {
+        // given
+        final var expectedErrorMessage = "Token expired";
+        final var aToken = RandomStringUtils.generateValue(36);
+        final var aPassword = "1234567Ab*";
+
+        final var aInput = new ResetPasswordApiInput(aPassword);
+
+        Mockito.when(resetPasswordUseCase.execute(Mockito.any(ResetPasswordCommand.class)))
+                .thenReturn(Either.left(NotificationHandler.create(new Error(expectedErrorMessage))));
+
+        final var request = MockMvcRequestBuilders.patch("/accounts/reset-password/{token}", aToken)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(this.mapper.writeValueAsString(aInput));
+
+        this.mvc.perform(request)
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(MockMvcResultMatchers.jsonPath("errors", hasSize(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.errors[0].message", equalTo(expectedErrorMessage)));
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/json/JacksonTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/json/JacksonTest.java
@@ -14,7 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 public class JacksonTest {
 
     @Test
-    public void testMarshall() {
+    void testMarshall() {
         final var aFirstName = "teste";
         final var aLastName = "testes";
         final var aEmail = "teste@teste.com";
@@ -28,7 +28,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void testUnarshall() {
+    void testUnarshall() {
         final var aFirstName = "teste";
         final var aLastName = "testes";
         final var aEmail = "teste@teste.com";
@@ -52,7 +52,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void testUnarshallThrowsException() {
+    void testUnarshallThrowsException() {
         Assertions.assertThrows(RuntimeException.class,
                 () -> Json.readValue(null, CreateAccountApiInput.class));
     }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/BcryptServiceTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/BcryptServiceTest.java
@@ -17,7 +17,7 @@ public class BcryptServiceTest {
     private BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Test
-    public void givenAValidRawPasswordAndEncodedPassword_whenCallMatches_shouldReturnTrue() {
+    void givenAValidRawPasswordAndEncodedPassword_whenCallMatches_shouldReturnTrue() {
         final var rawPassword = "1234567Ab";
         final var encodedPassword = bCryptPasswordEncoder.encode(rawPassword);
 
@@ -27,7 +27,7 @@ public class BcryptServiceTest {
     }
 
     @Test
-    public void givenAValidRawPassword_whenCallEncrypt_shouldReturnPasswordEncrypted() {
+    void givenAValidRawPassword_whenCallEncrypt_shouldReturnPasswordEncrypted() {
         final var rawPassword = "1234567Ab";
 
         final var actual = bcryptService.encrypt(rawPassword);
@@ -36,7 +36,7 @@ public class BcryptServiceTest {
     }
 
     @Test
-    public void givenAnInvalidRawPasswordAndValidEncodedPassword_whenCallMatches_shouldReturnFalse() {
+    void givenAnInvalidRawPasswordAndValidEncodedPassword_whenCallMatches_shouldReturnFalse() {
         final var rawPassword = "1234567Ab";
         final var encodedPassword = bCryptPasswordEncoder.encode("1234567Abc");
 

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/RabbitEventServiceTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/RabbitEventServiceTest.java
@@ -6,11 +6,8 @@ import com.kaua.ecommerce.users.infrastructure.configurations.json.Json;
 import com.kaua.ecommerce.users.infrastructure.services.EventService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +24,7 @@ public class RabbitEventServiceTest {
     private RabbitListenerTestHarness harness;
 
     @Test
-    public void shouldSendMessage() throws InterruptedException {
+    void shouldSendMessage() throws InterruptedException {
         final var aEvent = new com.kaua.ecommerce.users.domain.accounts.AccountCreatedEvent(
                 "123",
                 "teste",
@@ -48,14 +45,5 @@ public class RabbitEventServiceTest {
         final var actualMessage = invocationData.getArguments()[0].toString();
 
         Assertions.assertEquals(expectedMessage, actualMessage);
-    }
-}
-
-@Component
-class AccountCreatedNewsListener {
-
-    @RabbitListener(id = RabbitEventServiceTest.LISTENER, queues = "${amqp.queues.account-created.routing-key}")
-    public void onAccountCreated(@Payload final String message) {
-        System.out.println(message);
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/RabbitQueueServiceTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/RabbitQueueServiceTest.java
@@ -9,11 +9,8 @@ import com.kaua.ecommerce.users.infrastructure.configurations.annotations.EmailQ
 import com.kaua.ecommerce.users.infrastructure.configurations.json.Json;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.test.RabbitListenerTestHarness;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.stereotype.Component;
 
 import java.util.concurrent.TimeUnit;
 
@@ -30,7 +27,7 @@ public class RabbitQueueServiceTest {
     private RabbitListenerTestHarness harness;
 
     @Test
-    public void shouldSendMessage() throws InterruptedException {
+    void shouldSendMessage() throws InterruptedException {
         final var aMail = CreateMailQueueCommand.with(
                 RandomStringUtils.generateValue(36),
                 "Teste",
@@ -51,14 +48,5 @@ public class RabbitQueueServiceTest {
         final var actualMessage = invocationData.getArguments()[0].toString();
 
         Assertions.assertEquals(expectedMessage, actualMessage);
-    }
-}
-
-@Component
-class EmailSendListener {
-
-    @RabbitListener(id = RabbitQueueServiceTest.LISTENER, queues = "${amqp.queues.email-queue.routing-key}")
-    public void onEmailConfirmationSend(@Payload final String message) {
-        System.out.println(message);
     }
 }

--- a/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/listeners/RabbitListenersTest.java
+++ b/infrastructure/src/test/java/com/kaua/ecommerce/users/infrastructure/service/listeners/RabbitListenersTest.java
@@ -1,0 +1,21 @@
+package com.kaua.ecommerce.users.infrastructure.service.listeners;
+
+import com.kaua.ecommerce.users.infrastructure.service.RabbitEventServiceTest;
+import com.kaua.ecommerce.users.infrastructure.service.RabbitQueueServiceTest;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RabbitListenersTest {
+
+    @RabbitListener(id = RabbitEventServiceTest.LISTENER, queues = "${amqp.queues.account-created.routing-key}")
+    public void onAccountCreated(@Payload final String message) {
+        System.out.println(message);
+    }
+
+    @RabbitListener(id = RabbitQueueServiceTest.LISTENER, queues = "${amqp.queues.email-queue.routing-key}")
+    public void onEmailConfirmationSend(@Payload final String message) {
+        System.out.println(message);
+    }
+}


### PR DESCRIPTION
## Descrição

Adicionar a redefinição de senha.

## Mudanças Propostas

Foi adicionado a rota /request-reset-password que recebe um email, a rota /reset-password/{token} que recebe um token e a nova senha.

## Testes Realizados

Teste de unidade e integração

## Cobertura de Testes

O mínimo é 95%

## Problemas Conhecidos

É feito duas vezes uma request para buscar o usuário, o certo séria adicionar um outro identificador chamado email, se o accountId vier null o email precisa vir preenchido, se não lança uma exception

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
